### PR TITLE
fix: improve file extension handling

### DIFF
--- a/scripts/oj_download_tool.js
+++ b/scripts/oj_download_tool.js
@@ -20,13 +20,26 @@
         });
         return code;
     };
+    function getFileExtension() {
+        let language = document.querySelector('input[type="hidden"]').value;
+        const extensions = {
+            "C++": ".cpp",
+            "C": ".c",
+            "Java": ".java",
+            "Python2": ".py",
+            "Python3": ".py",
+            
+            "default": ".txt"
+        };
+        return extensions[language] || extensions.default;
+    }
     function downloadCode() {
         let blob = new Blob([getCode()], { type: "text/plain" });
         let fileName = window.location.pathname.slice(9);
         
         let a = document.createElement("a");
         a.href = window.URL.createObjectURL(blob);
-        a.download = fileName + ".cpp";
+        a.download = fileName + getFileExtension();
     
         document.body.appendChild(a);
         a.click();


### PR DESCRIPTION
Improve file extension handling to support multiple languages

Previously, the script only provided ".cpp" file extension for downloads, which would have caused issues for users selecting languages other than C++. Now, the script dynamically assigns the appropriate file extension based on the user's selected language, ensuring correct behavior for all supported languages.